### PR TITLE
Scan Docker image

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,32 +16,56 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # renovate: tag=v3
 
-      # Login against a Docker registry except on PR
+      # Extract metadata (tags, labels) for Docker
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@69f6fc9d46f2f8bf0d5491e4aabe0bb8c6a4678a # renovate: tag=v4
+        with:
+          images: swissgrc/azure-pipelines-terraform
+          tags: |
+            type=ref,event=tag
+            type=ref,event=pr
+            # set unstable tag for develop branch
+            type=raw,value=unstable,enable=${{ github.ref == format('refs/heads/{0}', 'develop') }}
+
+      # Build Docker image with Buildx
+      - name: Build Docker image
+        uses: docker/build-push-action@e551b19e49efd4e98792db7592c17c09b89db8d8 # renovate: tag=v3
+        with:
+          context: .
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      # Scan Docker image
+      - name: Scan Docker image
+        uses: aquasecurity/trivy-action@4b9b6fb4ef28b31450391a93ade098bb00de584e # renovate: tag=0.3.0
+        with:
+          image-ref: ${{ steps.meta.outputs.tags }}
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+
+      # Publish scan report to GitHub
+      - name: Publish scan report to GitHub        
+        uses: github/codeql-action/upload-sarif@a6611b86918424d4588efe7d6dbe18fe52d42518 # renovate: tag=v1
+        if: ${{ always() }}
+        with:
+          sarif_file: trivy-results.sarif
+
+      # Login to Docker registry if not PR build
       - name: Log in to Docker Hub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # renovate: tag=v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      
-      # Extract metadata (tags, labels) for Docker
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@69f6fc9d46f2f8bf0d5491e4aabe0bb8c6a4678a # renovate: tag=v4
-        with:
-          images: swissgrc/azure-pipelines-helm
-          tags: |
-            type=ref,event=tag
-            type=ref,event=pr
-            # set unstable tag for develop branch
-            type=raw,value=unstable,enable=${{ github.ref == format('refs/heads/{0}', 'develop') }}
-      
-      # Build and push Docker image with Buildx (don't push on PR)
-      - name: Build and push Docker image
-        id: build-and-push
+
+      # Publish Docker image for CI builds if not PR build
+      - name: Push container image
         uses: docker/build-push-action@e551b19e49efd4e98792db7592c17c09b89db8d8 # renovate: tag=v3
+        if: github.event_name != 'pull_request'
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Scan Docker image before publishing using [Trivy](https://github.com/aquasecurity/trivy). Alerts are not blocking for a pull request.