### PR TITLE
Use Debian based  base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.13.0-alpine3.11
+FROM node:16.15.0-buster-slim
 
 LABEL org.opencontainers.image.vendor="Swiss GRC AG"
 LABEL org.opencontainers.image.authors="Swiss GRC AG <opensource@swissgrc.com>"
@@ -8,19 +8,31 @@ LABEL org.opencontainers.image.url="https://github.com/swissgrc/docker-azure-pip
 LABEL org.opencontainers.image.source="https://github.com/swissgrc/docker-azure-pipelines-helm"
 LABEL org.opencontainers.image.documentation="https://github.com/swissgrc/docker-azure-pipelines-helm"
 
+# Required for Azure Pipelines Container Jobs
+LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/local/bin/node"
+
+# Kubectl
+
 ENV KUBE_VERSION=1.24.1
+
+RUN apt update -y && \
+  apt install -y wget && \
+  wget -q https://storage.googleapis.com/kubernetes-release/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl && \
+  chmod +x /usr/local/bin/kubectl && \
+  apt clean all && \
+  # Smoke test
+  kubectl version --client
+
+# Helm
+
 ENV HELM_VERSION=3.9.0
 
-RUN apk add --no-cache --virtual .pipeline-deps readline linux-pam \
-  && apk add bash sudo shadow \
-  && wget -q https://storage.googleapis.com/kubernetes-release/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl \
-  && chmod +x /usr/local/bin/kubectl \
-  && wget -q https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm \
-  && chmod +x /usr/local/bin/helm \
-  && apk del .pipeline-deps \
-  && kubectl version --client \
-  && helm version
-
-LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/local/bin/node"
+RUN apt update -y && \
+  apt install -y wget && \
+  wget -q https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm && \
+  chmod +x /usr/local/bin/helm && \
+  apt clean all && \
+  # Smoke test
+  helm version
 
 CMD [ "node" ]


### PR DESCRIPTION
Alpine enforces strict lower case user names. VMSS agents are running under a user `AzDevOps`, which results in Azure Pipelines Container jobs trying to create an user `AzDevOps_azpcontainer` which fails on Alpine. Unfortunately user name for VMSS agents can currently not be changed (see https://developercommunity.visualstudio.com/t/vmss-agents-cant-start-docker-container/1174823). 

This PR switches to to Debian based Node image which supports user names with mixed case, so that this image can also be used in Azure Pipelines Container jobs running on VMSS agents.