### PR TITLE
Replace apt with apt-get

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,12 @@ LABEL org.opencontainers.image.documentation="https://github.com/swissgrc/docker
 # renovate: datasource=github-tags depName=kubernetes/kubernetes extractVersion=^v(?<version>.*)$
 ENV KUBE_VERSION=1.24.2
 
-RUN apt update -y && \
-  apt install -y wget && \
+RUN apt-get update -y && \
+  apt-get install -y wget && \
   wget -q https://storage.googleapis.com/kubernetes-release/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl && \
   chmod +x /usr/local/bin/kubectl && \
-  apt clean all && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* && \
   # Smoke test
   kubectl version --client
 
@@ -26,10 +27,11 @@ RUN apt update -y && \
 # renovate: datasource=github-tags depName=helm/helm extractVersion=^v(?<version>.*)$
 ENV HELM_VERSION=3.9.0
 
-RUN apt update -y && \
-  apt install -y wget && \
+RUN apt-get update -y && \
+  apt-get install -y wget && \
   wget -q https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm && \
   chmod +x /usr/local/bin/helm && \
-  apt clean all && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* && \
   # Smoke test
   helm version


### PR DESCRIPTION
Replace `apt` with `apt-get` since `apt` is discouraged by the Linux distributions as an unattended tool as its interface may suffer changes between versions. 

See [DL3027](https://github.com/hadolint/hadolint/wiki/DL3027).