### PR TITLE
Build on top of Azure CLI image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:11.3-slim
+FROM swissgrc/azure-pipelines-azurecli:2.37.0
 
 LABEL org.opencontainers.image.vendor="Swiss GRC AG"
 LABEL org.opencontainers.image.authors="Swiss GRC AG <opensource@swissgrc.com>"
@@ -12,14 +12,8 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # renovate: datasource=github-tags depName=kubernetes/kubernetes extractVersion=^v(?<version>.*)$
 ENV KUBE_VERSION=1.24.2
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CACERTIFICATES_VERSION=20210119
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION=7.74.0-1.3+deb11u1
 
-RUN apt-get update -y && \
-  apt-get install -y --no-install-recommends ca-certificates=${CACERTIFICATES_VERSION} curl=${CURL_VERSION} && \
-  curl -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl && \
+RUN curl -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl && \
   chmod +x /usr/local/bin/kubectl && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* && \

--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ Docker image to run Helm and kubectl commands in [Azure Pipelines container jobs
 
 This container can be used to run Helm and kubectl commands in [Azure Pipelines container jobs].
 
+The following software is additionally available in the image:
+
+| Software   | Included since |
+|------------|----------------|
+| Azure Cli  | vNext          |
+| Git        | vNext          |
+| .NET       | vNext          |
+| Docker CLI | vNext          |
+
 ### Azure Pipelines Container Job
 
 To use the image in an Azure Pipelines Container Job add the following task use it with the `container` property.
@@ -43,12 +52,12 @@ The following example shows the container used for a deployment step
 ### Tags
 
 <!-- markdownlint-disable MD013 -->
-| Tag      | Description                                                    | Base Image             | Helm  | Kubectl | Size                                                                                                                          |
-|----------|----------------------------------------------------------------|------------------------|-------|---------|-------------------------------------------------------------------------------------------------------------------------------|
-| latest   | Latest stable release (from `main` branch)                     | debian:11.3-slim       | 3.9.0 | 1.24.2  | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-helm/latest?style=flat-square)   |
-| unstable | Latest unstable release (from `develop` branch)                | debian:11.3-slim       | 3.9.0 | 1.24.2  | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-helm/unstable?style=flat-square) |
-| 3.5.1    | [Helm 3.5.1](https://github.com/helm/helm/releases/tag/v3.5.1) | node:15.8.0-alpine3.11 | 3.5.1 | 1.20.2  | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-helm/3.5.1?style=flat-square)    |
-| 3.9.0    | [Helm 3.9.0](https://github.com/helm/helm/releases/tag/v3.9.0) | debian:11.3-slim       | 3.9.0 | 1.24.2  | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-helm/3.9.0?style=flat-square)    |
+| Tag      | Description                                                    | Base Image                               | Helm  | Kubectl | Size                                                                                                                          |
+|----------|----------------------------------------------------------------|------------------------------------------|-------|---------|-------------------------------------------------------------------------------------------------------------------------------|
+| latest   | Latest stable release (from `main` branch)                     | debian:11.3-slim                         | 3.9.0 | 1.24.2  | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-helm/latest?style=flat-square)   |
+| unstable | Latest unstable release (from `develop` branch)                | swissgrc/azure-pipelines-azurecli:2.37.0 | 3.9.0 | 1.24.2  | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-helm/unstable?style=flat-square) |
+| 3.5.1    | [Helm 3.5.1](https://github.com/helm/helm/releases/tag/v3.5.1) | node:15.8.0-alpine3.11                   | 3.5.1 | 1.20.2  | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-helm/3.5.1?style=flat-square)    |
+| 3.9.0    | [Helm 3.9.0](https://github.com/helm/helm/releases/tag/v3.9.0) | debian:11.3-slim                         | 3.9.0 | 1.24.2  | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-helm/3.9.0?style=flat-square)    |
 <!-- markdownlint-restore -->
 
 ### Configuration
@@ -59,7 +68,5 @@ These environment variables are supported:
 |------------------------|----------------------|------------------------------------------------------------------|
 | KUBE_VERSION           | `1.24.2`             | Version of kubectl installed in the image.                       |
 | HELM_VERSION           | `3.9.0`              | Version of Helm installed in the image.                          |
-| CACERTIFICATES_VERSION | `20210119`           | Version of `ca-certificates` package used to install components. |
-| CURL_VERSION           | `7.74.0-1.3+deb11u1` | Version of `curl` package used to install components.            |
 
 [Azure Pipelines container jobs]: https://docs.microsoft.com/en-us/azure/devops/pipelines/process/container-phases


### PR DESCRIPTION
Build on top of swissgrc/azure-pipelines-azurecli image which additionally brings .NET, Git and Azure CLI and Docker CLI into the image.