### PR TITLE
Switch base image to ghcr.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base image containing dependencies used in builder and final image
-FROM swissgrc/azure-pipelines-azurecli:2.46.0 AS base
+FROM ghcr.io/swissgrc/azure-pipelines-azurecli:2.46.0 AS base
 
 
 # Builder image


### PR DESCRIPTION
Base Image is now available on both Docker Hub and ghcr.io.